### PR TITLE
Optimized Use of Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,49 @@
 # Create ReactPy App
 
-This is `create-react-app` for ReactPy projects.
+This is create-react-app for your ReactPy projects!
+
+## Creating an App
+
+You'll need to have Python 3.8 or later installed on your machine. You can use `python --version` to check your current version.
+
+1. First, install the package using pip:
+
+```bash
+pip install create-reactpy-app
+```
+
+> Note: You can either install this globally or in a virtual environment.
+
+2. Create a new project:
+
+```bash
+create-reactpy-app my-app --backend flask
+```
+
+> Note: You can replace `flask` with `fastapi` or `starlette` if you want to use those frameworks instead. The default is already set to `flask`.
+
+3. Change directory to your new project:
+
+```bash
+cd my-app
+```
+
+4. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+5. Start the server; depending on the backend framework you chose, you can run the following commands:
+
+Flask:
+
+```bash
+gunicorn main:app
+```
+
+FastAPI or Starlette:
+
+```bash
+uvicorn main:app
+```

--- a/create_reactpy_app/__main__.py
+++ b/create_reactpy_app/__main__.py
@@ -5,15 +5,19 @@ from create_reactpy_app.settings import settings
 
 
 @click.command()
-@click.argument('app_name')
-def main(app_name):
+@click.argument('project_directory')
+@click.argument('backend')
+def main(project_directory, backend):
     """
     This command creates a template for a Reactpy app.
     """
 
     cookiecutter(
         settings.COOKIECUTTER_REPO_URL,
-        extra_context={'app_name': app_name},
+        extra_context={
+            'project_directory': project_directory,
+            'backend': backend
+        },
         no_input=True
     )
                 

--- a/create_reactpy_app/__main__.py
+++ b/create_reactpy_app/__main__.py
@@ -13,7 +13,8 @@ def main(app_name):
 
     cookiecutter(
         settings.COOKIECUTTER_REPO_URL,
-        extra_context={'app_name': app_name}
+        extra_context={'app_name': app_name},
+        no_input=True
     )
                 
 

--- a/create_reactpy_app/__main__.py
+++ b/create_reactpy_app/__main__.py
@@ -6,7 +6,12 @@ from create_reactpy_app.settings import settings
 
 @click.command()
 @click.argument('project_directory')
-@click.argument('backend')
+@click.option(
+    '--backend',
+    '-b',
+    default='flask',
+    help='The backend framework to use. Default is Flask.'
+)
 def main(project_directory, backend):
     """
     This command creates a template for a Reactpy app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.8"
 click = "^8.1.7"
 cookiecutter = "^2.6.0"
 pydantic-settings = "^2.2.1"


### PR DESCRIPTION
This PR achieves the following,

- The `app_name` param has been renamed to `project_directory` (similar to `create-react-app`)
- The `backend` arg (for the CLI command) has been converted to an option
- Specified a `no-input` parameter (when cloning the Cookicutter project) to eliminate the requirement for users to pass input
- Updated the supported Python versions to be `^3.8`
- Added some initial content to the `README`